### PR TITLE
Harpy/CodeGenMonad.hs: add missing import of 'firstBuffer'

### DIFF
--- a/Harpy/CodeGenMonad.hs
+++ b/Harpy/CodeGenMonad.hs
@@ -35,6 +35,7 @@ module Harpy.CodeGenMonad(
           Label,
           FixupKind(..),
           CodeGenConfig(..),
+          firstBuffer,
           defaultCodeGenConfig,
     -- * Functions
     -- ** General code generator monad operations


### PR DESCRIPTION
ghc-8.0.2-rc1 slightly changed TH import checking. Harpy
started failing as:

  Harpy/Call.hs:26:3: error:
    • Can't find interface-file declaration for variable Harpy.CodeGenMonad.firstBuffer
        Probable cause: bug in .hi-boot file, or inconsistent .hi file
        Use -ddump-if-trace to get an idea of which file caused the error
    • In the expression: Harpy.CodeGenMonad.firstBuffer state_atVU
      In an equation for ‘code_atVV’:
          code_atVV = Harpy.CodeGenMonad.firstBuffer state_atVU
      In the expression:
        do { let code_atVV = Harpy.CodeGenMonad.firstBuffer state_atVU;
             res_atVW <- (Control.Monad.IO.Class.liftIO
                          $ ((\ c_atVX -> conv (castPtrToFunPtr c_atVX) v_atVR) code_atVV));
             (return $ ((ustate_atVT, state_atVU), Right res_atVW)) }

The fix is to add import of missing symbol
at TH function definition site.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>